### PR TITLE
Added susano private discord in config & fix discord ids

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,11 @@ export const discordServers: DiscordServerMap = {
         id: "1079619316670021632",
         type: "cheats",
     },
+    "1142906613133496360": {
+        name: "Susano Private",
+        id: "1142906613133496360",
+        type: "cheats",
+    },
     "1303841395156451418": {
         name: "Susano Media",
         id: "1303841395156451418",

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,7 +69,7 @@ export const discordServers: DiscordServerMap = {
     },
     "1314957946383237130": {
         name: "Keyser Cheats",
-        id: "1252564455821283438",
+        id: "1314957946383237130",
         type: "cheats",
     },
     "1190354743181185075": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,7 +84,7 @@ export const discordServers: DiscordServerMap = {
     },
     "1116161366684881010": {
         name: "Absolute Co.",
-        id: "1131251754940497955",
+        id: "1116161366684881010",
         type: "cheats",
     },
     "1339264303286583398": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,7 @@ export const discordServers: DiscordServerMap = {
     },
     "1079619316670021632": {
         name: "Susano",
-        id: "1136029776080023563",
+        id: "1079619316670021632",
         type: "cheats",
     },
     "1303841395156451418": {


### PR DESCRIPTION
This pull request includes the following changes related to Discord identifiers in the configuration file:

✅ **Fixed incorrect Discord ID for the public Susano server**

✅ **Added the private Susano Discord ID to the config**

✅ **Corrected the Discord ID for Keyser**

✅ **Fixed an absolute Discord ID to ensure consistency and reliability**
